### PR TITLE
Blockdoor deletion fix

### DIFF
--- a/BlockDoor/BlockDoor.java
+++ b/BlockDoor/BlockDoor.java
@@ -585,7 +585,7 @@ public class BlockDoor extends Plugin
 			boolean foundIt = false;
             
 			while ((line = reader.readLine()) != null) {
-				if (!line.contains(type + ":" + creator + "*" + name))
+				if (!line.contains(type + ":" + creator + ":" + name))
 					text += line + "\r\n";
 				else {
 					if(!foundIt)


### PR DESCRIPTION
There was a typo in the BlockDoor plugin's `deleteItem` method that prevented doors/zones/triggers from being removed from the flatfile -- here's the one-byte fix.

(Hope I'm doing this right. First github pull request wooooo!)
