### PR TITLE
Added support for block tiers

### DIFF
--- a/HeyRunes/HeyRune.java
+++ b/HeyRunes/HeyRune.java
@@ -136,6 +136,10 @@ public class HeyRune
 		ArrayList<HeyRune> runes = new ArrayList<HeyRune>(_r);
 		HeyRune victor = null;
 		Direction victorD = null;
+
+		if( !HeyRuneTiers.ready ) {
+			HeyRuneTiers.init();
+		}
 		
 		int size = 0;
 		for (HeyRune r : runes) {
@@ -160,9 +164,9 @@ public class HeyRune
 							continue;
 						}
 						int myId = rune.idAt(index);
-						if (myId > 0) {
+						if (myId > 0 || myId == -2 || myId == -3 ) {
 							blockId =  etc.getServer().getBlockIdAt(xoffset + x, y,  zoffset + z);
-	                                                blockTier = HeyRuneTiers.tier[myId];
+	                                                blockTier = HeyRuneTiers.tier[blockId];
 							if(rune.north && myId != blockId) {
 								if(myId != -2 || blockTier != 0) { // Ink not permitted or ink not found
 									if(myId == -3 && rune.northTier == -1 && blockTier > 0) {// first tiered material
@@ -173,7 +177,7 @@ public class HeyRune
 								}
 							}
 							blockId =  etc.getServer().getBlockIdAt(zoffset + x, y,  -xoffset + z);
-	                                                blockTier = HeyRuneTiers.tier[myId];
+	                                                blockTier = HeyRuneTiers.tier[blockId];
 							if(rune.east && myId != blockId) {
 								if(myId != -2 || blockTier != 0) { // Ink not permitted or ink not found
 									if(myId == -3 && rune.eastTier == -1 && blockTier > 0) {// first tiered material
@@ -184,7 +188,7 @@ public class HeyRune
 								}
 							}
 							blockId =  etc.getServer().getBlockIdAt(-xoffset + x, y,  -zoffset + z);
-	                                                blockTier = HeyRuneTiers.tier[myId];
+	                                                blockTier = HeyRuneTiers.tier[blockId];
 							if(rune.south && myId != blockId) {
 								if(myId != -2 || blockTier != 0) { // Ink not permitted or ink not found
 									if(myId == -3 && rune.southTier == -1 && blockTier > 0) {// first tiered material
@@ -195,7 +199,7 @@ public class HeyRune
 								}
 							}
 							blockId =  etc.getServer().getBlockIdAt(-zoffset + x, y,  xoffset + z);
-	                                                blockTier = HeyRuneTiers.tier[myId];
+	                                                blockTier = HeyRuneTiers.tier[blockId];
 							if(rune.west && myId != blockId) {
 								if(myId != -2 || blockTier != 0) { // Ink not permitted or ink not found
 									if(myId == -3 && rune.westTier == -1 && blockTier > 0) {// first tiered material

--- a/HeyRunes/HeyRune.java
+++ b/HeyRunes/HeyRune.java
@@ -20,6 +20,10 @@ public class HeyRune
 	public boolean south = true;
 	public boolean east = true;
 	public boolean west = true;
+	public int northTier = -1;
+	public int southTier = -1;
+        public int eastTier  = -1;
+        public int westTier  = -1;
 	
 	public HeyRune(String in_name, int[][] in_pattern) {
 		name = in_name;
@@ -121,6 +125,11 @@ public class HeyRune
 		south = true;
 		east = true;
 		west = true;
+
+		northTier = -1;
+		southTier = -1;
+		eastTier = -1;
+		westTier = -1;
 	}
 	
 	public static HeyRune match(ArrayList<HeyRune> _r, int x, int y, int z) {
@@ -138,6 +147,8 @@ public class HeyRune
 		int xoffset = 0;
 		int yoffset = 0;
 		int zoffset = 0;
+		int blockId = 0;
+		int blockTier = 0;
 		for (int i = 0; index < size; ++i) {
 			for (int j = 0; j < ((i/2) + 1); ++j) {
 				try {
@@ -150,17 +161,49 @@ public class HeyRune
 						}
 						int myId = rune.idAt(index);
 						if (myId > 0) {
-							if(rune.north && myId != etc.getServer().getBlockIdAt(xoffset + x, y, zoffset + z)) {
-								rune.north = false;
+							blockId =  etc.getServer().getBlockIdAt(xoffset + x, y,  zoffset + z);
+	                                                blockTier = HeyRuneTiers.tier[myId];
+							if(rune.north && myId != blockId) {
+								if(myId != -2 || blockTier != 0) { // Ink not permitted or ink not found
+									if(myId == -3 && rune.northTier == -1 && blockTier > 0) {// first tiered material
+										rune.northTier = blockId;
+									} else if ( myId != -3 || blockId != rune.northTier ) {
+										rune.north = false;
+									}
+								}
 							}
-							if(rune.east && myId != etc.getServer().getBlockIdAt(zoffset + x, y, -xoffset + z)) {
-								rune.east = false;
+							blockId =  etc.getServer().getBlockIdAt(zoffset + x, y,  -xoffset + z);
+	                                                blockTier = HeyRuneTiers.tier[myId];
+							if(rune.east && myId != blockId) {
+								if(myId != -2 || blockTier != 0) { // Ink not permitted or ink not found
+									if(myId == -3 && rune.eastTier == -1 && blockTier > 0) {// first tiered material
+										rune.eastTier = blockId;
+									} else if ( myId != -3 || blockId != rune.eastTier ) {
+										rune.east = false;
+									}
+								}
 							}
-							if(rune.south && myId != etc.getServer().getBlockIdAt(-xoffset + x, y, -zoffset + z)) {
-								rune.south = false;
+							blockId =  etc.getServer().getBlockIdAt(-xoffset + x, y,  -zoffset + z);
+	                                                blockTier = HeyRuneTiers.tier[myId];
+							if(rune.south && myId != blockId) {
+								if(myId != -2 || blockTier != 0) { // Ink not permitted or ink not found
+									if(myId == -3 && rune.southTier == -1 && blockTier > 0) {// first tiered material
+										rune.southTier = blockId;
+									} else if ( myId != -3 || blockId != rune.southTier ) {
+										rune.south = false;
+									}
+								}
 							}
-							if(rune.west && myId != etc.getServer().getBlockIdAt(-zoffset + x, y, xoffset + z)) {
-								rune.west = false;
+							blockId =  etc.getServer().getBlockIdAt(-zoffset + x, y,  xoffset + z);
+	                                                blockTier = HeyRuneTiers.tier[myId];
+							if(rune.west && myId != blockId) {
+								if(myId != -2 || blockTier != 0) { // Ink not permitted or ink not found
+									if(myId == -3 && rune.westTier == -1 && blockTier > 0) {// first tiered material
+										rune.westTier = blockId;
+									} else if ( myId != -3 || blockId != rune.westTier ) {
+										rune.west = false;
+									}
+								}
 							}
 						}
 						if (index + 1 == rune.size()) {

--- a/HeyRunes/HeyRuneTiers.java
+++ b/HeyRunes/HeyRuneTiers.java
@@ -1,0 +1,58 @@
+/**
+* HeyRune.java - Extend this and register it to listen to specific hooks.
+* @author raphfrk
+*/
+	
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+	
+	
+public class HeyRuneTiers {
+	
+	static public int[] tier = new int[512]; 
+	
+	public void HeyRuneTiers() {
+	
+		PropertiesFile pf = new PropertiesFile( "HeyRuneTiers.txt" );
+		pf.load();
+	
+		// Probably should do better checking here
+		if( !pf.keyExists("Tier_0") ) {
+			pf.setString("Tier_0" , "0,1,2,3");
+			pf.setString("Tier_1" , "4,5,12,13,17");
+			pf.setString("Tier_2" , "20");
+			pf.setString("Tier_3" , "15,45,82,73,74");
+			pf.setString("Tier_4" , "7,14,42,48");
+			pf.setString("Tier_5" , "41,49");
+			pf.setString("Tier_6" , "57");
+		}
+
+		pf.save();
+	
+		int cnt;
+	
+		for(cnt=0;cnt<512;cnt++) {
+			tier[cnt] = -1;
+		}
+	
+		for(cnt=0;cnt<6;cnt++) {
+			String key = "Tier_" + cnt;
+			if(pf.keyExists(key)) {
+				for( String id : pf.getString(key).split(",") ) {
+					if( !id.equals("") ) {
+						int idInt = Integer.parseInt(id);
+						tier[idInt] = cnt;
+					}
+				}
+			}
+		}	
+	
+	}
+	
+}
+	
+	
+			
+	

--- a/HeyRunes/HeyRuneTiers.java
+++ b/HeyRunes/HeyRuneTiers.java
@@ -12,9 +12,18 @@ import java.util.logging.Logger;
 public class HeyRuneTiers {
 	
 	static public int[] tier = new int[512]; 
-	
-	public void HeyRuneTiers() {
-	
+
+	static boolean ready = false;
+
+	public HeyRuneTiers() {
+
+		init();
+
+	}
+
+
+	static public void init() {
+
 		PropertiesFile pf = new PropertiesFile( "HeyRuneTiers.txt" );
 		pf.load();
 	


### PR DESCRIPTION
These changes allow for 3 special pattern match codes

Code:

-1 = don't care
-2 = must be an "ink" block (=Tier 0)
-3 = must be a tier block (=Tier > 0)

It also reads from a properties file to allow the files to be set up.

When it first matches a tiered block, it remembers it for the rest of the rune.  Also tier blocks must be identical for a particular rune
